### PR TITLE
fix: compiling errors occuring with typst 0.13.*

### DIFF
--- a/chapters/1_introduction.typ
+++ b/chapters/1_introduction.typ
@@ -1,6 +1,6 @@
 
 #import "/common/todo.typ": *
-#import "@preview/glossarium:0.2.6": gls, glspl
+#import "@preview/glossarium:0.5.4": gls, glspl
 #import "/thesis/template.typ": flex-caption
 
 = Introduction

--- a/exposé/template.typ
+++ b/exposé/template.typ
@@ -42,14 +42,14 @@
     margin: (left: 2.5cm, right: 2.5cm, top: 4cm, bottom: 2.5cm),
     numbering: "1 / 1",
     number-align: center,
-    footer: locate(currentLocation => {
+    footer: context {
       let currentPage = counter(page).display()
-      let finalPage = counter(page).final(currentLocation).first()
+      let finalPage = counter(page).final().first()
   
       line(length: 100%, stroke: (paint: gray))
       align(center)[#currentPage / #finalPage]
     })
-  )
+
   counter(page).update(1)
 
   // Body Font Family

--- a/thesis.typ
+++ b/thesis.typ
@@ -1,9 +1,11 @@
 #import "thesis/template.typ": *
 #import "common/todo.typ": *
 #import "metadata.typ": *
-#import "@preview/glossarium:0.2.6": make-glossary
+#import "@preview/glossarium:0.5.4": make-glossary, register-glossary
+#import "/abbreviations.typ": abbreviations
 
 #show: make-glossary
+#register-glossary(abbreviations)
 #show: thesis.with(
   degree: degree,
   program: program,

--- a/thesis/template.typ
+++ b/thesis/template.typ
@@ -1,12 +1,10 @@
 #import "/common/titlepage.typ": *
 #import "/common/settings.typ": *
-#import "@preview/glossarium:0.2.6": print-glossary
+#import "@preview/glossarium:0.5.4": print-glossary
 #import "/abbreviations.typ": abbreviations
 
 #let in-outline = state("in-outline", false)
-#let flex-caption(long, short) = locate(loc => 
-    if in-outline.at(loc) { short } else { long }
-)
+#let flex-caption(long, short) = context if in-outline.get() { short } else { long }
 
 #let thesis(
   degree: "",
@@ -106,7 +104,7 @@
       
     },
     target: heading.where(supplement: [Chapter], outlined: true),
-    indent: true,
+    indent: auto,
     depth: 3
   )
   
@@ -179,22 +177,21 @@
   
   set page(
     // Header with current heading
-    header: locate(location => {
+    header: context {
       let elements = query(
-        selector(heading.where(depth: 1)).after(location), 
-        location
+        selector(heading.where(depth: 1)).after(here())
       )
 
       // Don't show header if a new chapter is starting at the current page
-      if elements != () and elements.first().location().page() == location.page() and elements.first().depth == 1 {
+      if elements != () and elements.first().location().page() == here().page() and elements.first().depth == 1 {
           return;
       }
 
       let displayHeading
       let displayNumbering
       let element
-      elements = query(selector(heading).after(location), location)
-      if elements != () and elements.first().location().page() == location.page() {
+      elements = query(selector(heading).after(here()))
+      if elements != () and elements.first().location().page() == here().page() {
         element = elements.first()
         if element.has("numbering") and element.numbering != none {
           displayNumbering = numbering(element.numbering, ..counter(heading).at(element.location()))
@@ -206,9 +203,7 @@
       } else {
         // Otherwise take the next heading backwards
         elements = query(
-          heading.where().before(location), 
-          location
-        )
+          heading.where().before(here())        )
         if elements != () {
           element = elements.last()
           if element.has("numbering") and element.numbering != none {
@@ -223,16 +218,16 @@
 
       align(center, displayNumbering + " " + displayHeading)
       line(length: 100%, stroke: (paint: gray))
-    }),
+    },
     
     // Footer with Page Numbering
-    footer: locate(currentLocation => {
+    footer: context {
       let currentPage = counter(page).display()
-      let finalPage = counter(page).final(currentLocation).first()
+      let finalPage = counter(page).final().first()
   
       line(length: 100%, stroke: (paint: gray))
       align(center)[#currentPage / #finalPage]
-    })
+    }
   )
 
   set page(
@@ -255,7 +250,7 @@
       heading("Appendix", outlined: true, numbering: none)
     },
     target: heading.where(supplement: [Appendix], outlined: true),
-    indent: true,
+    indent: auto,
     depth: 3
   )
 


### PR DESCRIPTION
- I replaced `locate(loc => { ... })` with `context { ...  }` and the `loc` with `here()`
- Fixed the flex-caption aswell (based on https://forum.typst.app/t/how-to-have-different-text-shown-in-figure-caption-and-in-outline/2349/2)
- Upgraded the glossary dep. to 0.5.4 and added a register #register-glossary.

-> Now the template compiles with typst@0.13.1